### PR TITLE
Add Terraform and GitHub Actions for S3 bucket

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,34 @@
+name: Terraform
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: hashicorp/setup-terraform@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: eu-west-2
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+
+      - name: Terraform Apply
+        run: terraform -chdir=terraform apply -auto-approve
+        env:
+          TF_VAR_bucket_name: ontoscale-ai-london-test4
+          TF_VAR_aws_region: eu-west-2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.terraform/
+terraform.tfstate*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # openai-with-aws-test3
+
+This project provisions an S3 bucket using Terraform executed from GitHub Actions.
+
+- **S3 Bucket:** `ontoscale-ai-london-test4`
+- **Terraform Backend Bucket:** `ontoscale-terraform-backend`
+- **AWS Access:** uses OIDC to assume the role stored in the `AWS_ROLE` GitHub secret.
+
+The workflow in `.github/workflows/terraform.yml` initializes Terraform and applies the configuration automatically on pushes to `main`.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.0"
+  backend "s3" {
+    bucket = "ontoscale-terraform-backend"
+    key    = "openai-with-aws-test3/terraform.tfstate"
+    region = "eu-west-2"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = var.bucket_name
+}
+
+variable "aws_region" {
+  type    = string
+  default = "eu-west-2"
+}
+
+variable "bucket_name" {
+  type    = string
+  default = "ontoscale-ai-london-test4"
+}


### PR DESCRIPTION
## Summary
- add Terraform config to create bucket `ontoscale-ai-london-test4`
- configure remote state in `ontoscale-terraform-backend`
- create GitHub Actions workflow that uses OIDC role from `AWS_ROLE`
- document how the workflow works
- ignore local terraform files

## Testing
- `terraform fmt -check terraform/main.tf`
- `terraform -chdir=terraform init -backend=false`


------
https://chatgpt.com/codex/tasks/task_e_687672577e9083318cb7ba122291802d