### PR TITLE
Fix S3 backend region

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -22,7 +22,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
-          aws-region: eu-west-2
+          aws-region: us-east-1
 
       - name: Terraform Init
         run: terraform -chdir=terraform init

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project provisions an S3 bucket using Terraform executed from GitHub Actions.
 
 - **S3 Bucket:** `ontoscale-ai-london-test4`
-- **Terraform Backend Bucket:** `ontoscale-terraform-backend`
+- **Terraform Backend Bucket:** `ontoscale-terraform-backend` (region `us-east-1`)
 - **AWS Access:** uses OIDC to assume the role stored in the `AWS_ROLE` GitHub secret.
 
 The workflow in `.github/workflows/terraform.yml` initializes Terraform and applies the configuration automatically on pushes to `main`.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,7 @@ terraform {
   backend "s3" {
     bucket = "ontoscale-terraform-backend"
     key    = "openai-with-aws-test3/terraform.tfstate"
-    region = "eu-west-2"
+    region = "us-east-1"
   }
   required_providers {
     aws = {


### PR DESCRIPTION
## Summary
- point S3 backend to the correct us-east-1 region
- configure GitHub Actions AWS region to us-east-1
- document backend region in README

## Testing
- `terraform -chdir=terraform fmt -check`
- `terraform -chdir=terraform init -backend=false`


------
https://chatgpt.com/codex/tasks/task_e_6876771c88208331b7f5457e6d0b6df3