### PR TITLE
Add teardown workflow, restrict deploy trigger

### DIFF
--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -1,15 +1,14 @@
-name: Terraform
+name: Teardown
 
 on:
-  push:
-    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  terraform:
+  destroy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,8 +24,8 @@ jobs:
       - name: Terraform Init
         run: terraform -chdir=terraform init
 
-      - name: Terraform Apply
-        run: terraform -chdir=terraform apply -auto-approve
+      - name: Terraform Destroy
+        run: terraform -chdir=terraform destroy -auto-approve
         env:
           TF_VAR_bucket_name: ontoscale-ai-london-test4
           TF_VAR_aws_region: eu-west-2


### PR DESCRIPTION
## Summary
- add a teardown workflow for destroying infrastructure
- trigger terraform deploy on pushes to main branch

## Testing
- `terraform fmt -check main.tf`
- `terraform init -backend=false`
- `terraform validate`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687679b8dff48331b8044d8ccddd7170